### PR TITLE
Pin Trivy action version in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           run: docker pull ghcr.io/oct8l/bfg-dockerized:"$GITHUB_RUN_ID"
 
         - name: Run Trivy for HIGH,CRITICAL CVEs and report (blocking)
-          uses: aquasecurity/trivy-action@master
+          uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
           with:
             image-ref: ghcr.io/oct8l/bfg-dockerized:${{ github.run_id }}
             exit-code: 0


### PR DESCRIPTION
To help protect against supply chain attacks, versions should always be pinned and Renovate will suggest updates to them.