### PR TITLE
Harden multi-architecture image CI and automate dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,3 +211,61 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+  hadolint:
+    name: Hadolint
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/hadolint.yml
+    permissions:
+      contents: read
+
+  shellcheck:
+    name: ShellCheck
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/shellcheck.yml
+    permissions:
+      contents: read
+
+  pr-ci-gate:
+    name: PR CI Gate
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs:
+      - build-test-image
+      - test-integration
+      - scan-image
+      - build-and-push-docker-image
+      - hadolint
+      - shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Verify required jobs succeeded
+        env:
+          BUILD_RESULT: ${{ needs.build-test-image.result }}
+          INTEGRATION_RESULT: ${{ needs.test-integration.result }}
+          SCAN_RESULT: ${{ needs.scan-image.result }}
+          FINAL_IMAGE_RESULT: ${{ needs.build-and-push-docker-image.result }}
+          HADOLINT_RESULT: ${{ needs.hadolint.result }}
+          SHELLCHECK_RESULT: ${{ needs.shellcheck.result }}
+        run: |
+          failures=0
+
+          for result in \
+            "Build test images:$BUILD_RESULT" \
+            "Integration tests:$INTEGRATION_RESULT" \
+            "Security scans:$SCAN_RESULT" \
+            "Final image build:$FINAL_IMAGE_RESULT" \
+            "Hadolint:$HADOLINT_RESULT" \
+            "ShellCheck:$SHELLCHECK_RESULT"
+          do
+            name=${result%%:*}
+            status=${result#*:}
+            echo "$name: $status"
+
+            if [[ "$status" != "success" ]]; then
+              failures=1
+            fi
+          done
+
+          exit "$failures"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   TEST_IMAGE: local-bfg:test
+  DOCKER_BUILD_RECORD_RETENTION_DAYS: ${{ github.event_name == 'pull_request' && 1 || 0 }}
   FINAL_IMAGE_CACHE_FROM: |
     type=gha
     type=gha,scope=test-image-amd64
@@ -120,8 +121,10 @@ jobs:
         include:
           - platform: linux/amd64
             artifact: test-image-amd64
+            category: results
           - platform: linux/arm64
             artifact: test-image-arm64
+            category: trivy-arm64
 
     permissions:
       contents: read
@@ -157,7 +160,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results-${{ matrix.artifact }}.sarif
-          category: trivy-${{ matrix.artifact }}
+          category: ${{ matrix.category }}
 
   build-and-push-docker-image:
     name: Build and Push Docker Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,24 +48,33 @@ jobs:
           platforms: linux/amd64
 
   test-integration:
-      name: Integration tests in Docker Compose
-      needs: [build-test-image]
-      runs-on: ubuntu-latest
+    name: Test Built Image
+    needs: [build-test-image]
+    runs-on: ubuntu-latest
 
-      permissions:
-        packages: read
+    permissions:
+      packages: read
 
-      steps:
+    env:
+      TEST_IMAGE: ghcr.io/oct8l/bfg-dockerized:${{ github.run_id }}
 
-        - name: Checkout git repo
-          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    steps:
 
-        - name: Login to ghcr.io registry
-          uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-          with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout git repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Login to ghcr.io registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image under test
+        run: docker pull "$TEST_IMAGE"
+
+      - name: Test built image
+        run: ./tests/test-image.sh "$TEST_IMAGE"
 
   scan-image:
       name: Scan Image with Trivy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,6 @@ jobs:
     permissions:
       contents: read
 
-    env:
-      DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
-
     steps:
 
       - name: Checkout git repo
@@ -108,6 +105,8 @@ jobs:
         run: docker load --input "${{ runner.temp }}/${{ matrix.artifact }}.tar"
 
       - name: Test built image
+        env:
+          DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
         run: ./tests/test-image.sh "${{ env.TEST_IMAGE }}"
 
   scan-image:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,115 +13,162 @@ on:
   schedule:
     - cron: '30 5 1,15 * *'
 
+env:
+  TEST_IMAGE: local-bfg:test
+  FINAL_IMAGE_CACHE_FROM: |
+    type=gha
+    type=gha,scope=test-image-amd64
+    type=gha,scope=test-image-arm64
+
 jobs:
 
   build-test-image:
-    name: Build Image for Testing & Scanning
+    name: Build Test Image (${{ matrix.platform }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            artifact: test-image-amd64
+          - platform: linux/arm64
+            artifact: test-image-arm64
 
     permissions:
-      packages: write
+      contents: read
 
     steps:
 
       - name: Checkout git repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push to GHCR
+      - name: Build and export test image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          push: true
-          tags: ghcr.io/oct8l/bfg-dockerized:${{ github.run_id }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          tags: ${{ env.TEST_IMAGE }}
+          outputs: type=docker,dest=${{ runner.temp }}/${{ matrix.artifact }}.tar
+          cache-from: |
+            type=gha
+            type=gha,scope=${{ matrix.artifact }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.artifact }}
+          platforms: ${{ matrix.platform }}
+
+      - name: Upload test image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}/${{ matrix.artifact }}.tar
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 7 }}
 
   test-integration:
-    name: Test Built Image
+    name: Test Built Image (${{ matrix.platform }})
     needs: [build-test-image]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            artifact: test-image-amd64
+          - platform: linux/arm64
+            artifact: test-image-arm64
 
     permissions:
-      packages: read
+      contents: read
 
     env:
-      TEST_IMAGE: ghcr.io/oct8l/bfg-dockerized:${{ github.run_id }}
+      DOCKER_DEFAULT_PLATFORM: ${{ matrix.platform }}
 
     steps:
 
       - name: Checkout git repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Login to ghcr.io registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
-      - name: Pull image under test
-        run: docker pull "$TEST_IMAGE"
+      - name: Download test image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}
+
+      - name: Load test image
+        run: docker load --input "${{ runner.temp }}/${{ matrix.artifact }}.tar"
 
       - name: Test built image
-        run: ./tests/test-image.sh "$TEST_IMAGE"
+        run: ./tests/test-image.sh "${{ env.TEST_IMAGE }}"
 
   scan-image:
-      name: Scan Image with Trivy
-      needs: [build-test-image]
-      runs-on: ubuntu-latest
+    name: Scan Image with Trivy (${{ matrix.platform }})
+    needs: [build-test-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            artifact: test-image-amd64
+          - platform: linux/arm64
+            artifact: test-image-arm64
 
-      permissions:
-        contents: read
-        packages: read
-        security-events: write
+    permissions:
+      contents: read
+      security-events: write
 
-      steps:
+    steps:
 
-        - name: Checkout git repo
-          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout git repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-        - name: Login to ghcr.io registry
-          uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-          with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download test image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}
 
-        - name: Pull image to scan
-          run: docker pull ghcr.io/oct8l/bfg-dockerized:"$GITHUB_RUN_ID"
+      - name: Load test image
+        run: docker load --input "${{ runner.temp }}/${{ matrix.artifact }}.tar"
 
-        - name: Run Trivy for HIGH,CRITICAL CVEs and report (blocking)
-          uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
-          with:
-            image-ref: ghcr.io/oct8l/bfg-dockerized:${{ github.run_id }}
-            exit-code: 0
-            ignore-unfixed: true
-            vuln-type: 'os,library'
-            severity: 'HIGH,CRITICAL'
-            format: 'sarif'
-            output: 'results.sarif'
+      - name: Run Trivy for HIGH,CRITICAL CVEs and report (blocking)
+        uses: aquasecurity/trivy-action@c07df6fec6fa692e6fd1200d50aaa1fdd66f03c8 # master
+        with:
+          image-ref: ${{ env.TEST_IMAGE }}
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'HIGH,CRITICAL'
+          format: 'sarif'
+          output: results-${{ matrix.artifact }}.sarif
 
-        - name: Upload Trivy scan results to GitHub Security tab
-          uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
-          with:
-            sarif_file: results.sarif
-            category: results
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: results-${{ matrix.artifact }}.sarif
+          category: trivy-${{ matrix.artifact }}
 
   build-and-push-docker-image:
     name: Build and Push Docker Image
     needs: [test-integration, scan-image]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code
@@ -158,7 +205,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          cache-from: ${{ env.FINAL_IMAGE_CACHE_FROM }}
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -1,0 +1,24 @@
+name: Hadolint
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run Hadolint
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: warning

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,21 @@
+name: ShellCheck
+
+on:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Lint shell scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run ShellCheck
+        run: find . -name '*.sh' -not -path '*/.*' -print0 | xargs -0 shellcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
 FROM amazoncorretto:25.0.3-alpine@sha256:32d81edae73e1670244827c2f12e5bcf0d335f035b538455fe9d02eb0771d41b
 
 ## Sourced from https://rtyley.github.io/bfg-repo-cleaner/
+# renovate: datasource=github-releases depName=rtyley/bfg-repo-cleaner extractVersion=^v(?<version>.+)$ versioning=semver
 ENV BFG_VERSION="1.15.0"
-ENV BFG_CHECKSUM="dfe2885adc2916379093f02a80181200536856c9a987bf21c492e452adefef7a"
+# renovate: datasource=repology depName=alpine_3_24/shadow versioning=apk
+ENV SHADOW_VERSION="4.18.0-r1"
 ENV HOME="/home/bfg"
 
-# hadolint ignore=DL3018
 RUN apk --no-cache upgrade && \
-    apk add --no-cache shadow && \
+    apk add --no-cache "shadow=$SHADOW_VERSION" && \
     adduser -D -h $HOME bfg && \
     chown -R bfg:bfg $HOME && \
     wget -q "https://repo1.maven.org/maven2/com/madgag/bfg/$BFG_VERSION/bfg-$BFG_VERSION.jar" \
-    -O "bfg-$BFG_VERSION.jar" \
-    && echo "$BFG_CHECKSUM  bfg-$BFG_VERSION.jar" > bfg.sha256 \
-    && sha256sum -c bfg.sha256 \
-    && rm bfg.sha256 \
+        -O "bfg-$BFG_VERSION.jar" \
+    && wget -q "https://repo1.maven.org/maven2/com/madgag/bfg/$BFG_VERSION/bfg-$BFG_VERSION.jar.sha1" \
+        -O bfg.sha1.expected \
+    && printf '%s  %s\n' "$(cat bfg.sha1.expected)" "bfg-$BFG_VERSION.jar" > bfg.sha1 \
+    && sha1sum -c bfg.sha1 \
+    && rm bfg.sha1 bfg.sha1.expected \
     && mv "bfg-$BFG_VERSION.jar" /home/bfg/bfg.jar
 
 WORKDIR "$HOME/workspace"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ ENV BFG_VERSION="1.15.0"
 ENV BFG_CHECKSUM="dfe2885adc2916379093f02a80181200536856c9a987bf21c492e452adefef7a"
 ENV HOME="/home/bfg"
 
+# hadolint ignore=DL3018
 RUN apk --no-cache upgrade && \
     apk add --no-cache shadow && \
     adduser -D -h $HOME bfg && \
     chown -R bfg:bfg $HOME && \
-    wget "https://repo1.maven.org/maven2/com/madgag/bfg/$BFG_VERSION/bfg-$BFG_VERSION.jar" \
+    wget -q "https://repo1.maven.org/maven2/com/madgag/bfg/$BFG_VERSION/bfg-$BFG_VERSION.jar" \
     -O "bfg-$BFG_VERSION.jar" \
-    && echo "$BFG_CHECKSUM  bfg-$BFG_VERSION.jar" | sha256sum -c - \
+    && echo "$BFG_CHECKSUM  bfg-$BFG_VERSION.jar" > bfg.sha256 \
+    && sha256sum -c bfg.sha256 \
+    && rm bfg.sha256 \
     && mv "bfg-$BFG_VERSION.jar" /home/bfg/bfg.jar
 
 WORKDIR "$HOME/workspace"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>c-gerke/renovate-config"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update versions declared by Renovate comments in the Dockerfile",
+      "managerFilePatterns": [
+        "/^Dockerfile$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))? versioning=(?<versioning>\\S+)\\s+ENV [A-Z][A-Z0-9_]*=\"(?<currentValue>[^\"]+)\""
+      ]
+    }
   ]
 }

--- a/tests/test-image.sh
+++ b/tests/test-image.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 image="${1:?usage: tests/test-image.sh IMAGE}"
 workspace="$(mktemp -d)"
+passed_tests=0
 
 cleanup() {
   exit_code=$?
@@ -21,6 +22,27 @@ cleanup() {
 }
 trap cleanup EXIT
 
+github_group_start() {
+  local title="$1"
+
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::group::$title"
+  fi
+}
+
+github_group_end() {
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::endgroup::"
+  fi
+}
+
+pass_test() {
+  local name="$1"
+
+  ((passed_tests += 1))
+  echo "PASS: $name"
+}
+
 fail() {
   echo "FAIL: $*" >&2
   return 1
@@ -29,6 +51,7 @@ fail() {
 setup_case() {
   local name="$1"
 
+  case_name="$name"
   case_dir="$workspace/$name"
   source_repo="$case_dir/source"
   mirror_repo="$case_dir/repo.git"
@@ -56,10 +79,20 @@ mirror_fixture() {
 }
 
 run_bfg() {
-  docker run --rm \
+  local exit_code
+
+  github_group_start "BFG output: $case_name"
+  if docker run --rm \
     --volume "$case_dir:/home/bfg/workspace" \
     "$image" \
-    "$@" repo.git
+    "$@" repo.git; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+  github_group_end
+
+  return "$exit_code"
 }
 
 assert_repo_valid() {
@@ -129,6 +162,8 @@ test_image_contract() {
     test "$PWD" = /home/bfg/workspace
     test -r /home/bfg/bfg.jar
   '
+
+  pass_test "image contract"
 }
 
 test_safe_rewrite() {
@@ -165,6 +200,7 @@ test_safe_rewrite() {
   assert_no_path_history credential.json
   assert_no_reachable_text "super-secret"
   assert_repo_valid
+  pass_test "protected historical rewrite"
 }
 
 test_protected_head() {
@@ -190,6 +226,7 @@ test_protected_head() {
   assert_ref_content refs/heads/main credential.json "super-secret"
   assert_ref_content refs/heads/main keep.txt "keep me"
   assert_repo_valid
+  pass_test "default current-content protection"
 }
 
 test_unprotected_rewrite() {
@@ -217,6 +254,7 @@ test_unprotected_rewrite() {
   assert_no_path_history credential.json
   assert_no_reachable_text "super-secret"
   assert_repo_valid
+  pass_test "unprotected current-content rewrite"
 }
 
 test_replace_text() {
@@ -243,6 +281,7 @@ test_replace_text() {
   assert_ref_content refs/heads/main keep.txt "keep me"
   assert_no_reachable_text "super-secret"
   assert_repo_valid
+  pass_test "sensitive-text replacement"
 }
 
 test_strip_large_blobs() {
@@ -264,6 +303,7 @@ test_strip_large_blobs() {
   assert_ref_content refs/heads/main small.txt "small file"
   assert_no_path_history large.bin
   assert_repo_valid
+  pass_test "large-blob stripping"
 }
 
 test_glob_delete_across_refs() {
@@ -315,6 +355,7 @@ test_glob_delete_across_refs() {
   assert_no_path_history feature.log
   assert_no_reachable_text "discard-"
   assert_repo_valid
+  pass_test "multi-ref glob and folder deletion"
 }
 
 test_image_contract
@@ -324,3 +365,5 @@ test_unprotected_rewrite
 test_replace_text
 test_strip_large_blobs
 test_glob_delete_across_refs
+
+echo "SUMMARY: $passed_tests image integration scenarios passed"

--- a/tests/test-image.sh
+++ b/tests/test-image.sh
@@ -6,16 +6,21 @@ image="${1:?usage: tests/test-image.sh IMAGE}"
 workspace="$(mktemp -d)"
 passed_tests=0
 
-cleanup() {
-  exit_code=$?
+restore_permissions() {
+  local directory="$1"
 
   docker run --rm \
     --user root \
     --entrypoint sh \
-    --volume "$workspace:/workspace" \
+    --volume "$directory:/workspace" \
     "$image" \
-    -c 'chmod -R a+rwX /workspace' \
-    >/dev/null 2>&1 || true
+    -c 'chmod -R a+rwX /workspace'
+}
+
+cleanup() {
+  exit_code=$?
+
+  restore_permissions "$workspace" >/dev/null 2>&1 || true
   rm -rf -- "$workspace" || true
 
   return "$exit_code"
@@ -358,6 +363,44 @@ test_glob_delete_across_refs() {
   pass_test "multi-ref glob and folder deletion"
 }
 
+test_garbage_collection() {
+  local removed_blob
+
+  echo "==> prune unreachable data after a rewrite"
+  setup_case "garbage-collection"
+
+  printf '%s\n' "super-secret" >"$source_repo/credential.json"
+  printf '%s\n' "keep me" >"$source_repo/keep.txt"
+  commit_fixture "Add removable content"
+  mirror_fixture
+
+  removed_blob="$(
+    git --git-dir="$mirror_repo" \
+      rev-parse refs/heads/main:credential.json
+  )"
+
+  run_bfg --no-blob-protection --delete-files credential.json
+
+  assert_ref_missing refs/heads/main credential.json
+  assert_ref_content refs/heads/main keep.txt "keep me"
+  assert_no_path_history credential.json
+  assert_no_reachable_text "super-secret"
+
+  git --git-dir="$mirror_repo" cat-file -e "$removed_blob" ||
+    fail "removed blob disappeared before garbage collection"
+
+  restore_permissions "$case_dir"
+  git --git-dir="$mirror_repo" reflog expire --expire=now --all
+  git --git-dir="$mirror_repo" gc --quiet --prune=now --aggressive
+
+  if git --git-dir="$mirror_repo" cat-file -e "$removed_blob" 2>/dev/null; then
+    fail "removed blob still exists after garbage collection"
+  fi
+
+  assert_repo_valid
+  pass_test "garbage collection prunes unreachable data"
+}
+
 test_image_contract
 test_safe_rewrite
 test_protected_head
@@ -365,5 +408,6 @@ test_unprotected_rewrite
 test_replace_text
 test_strip_large_blobs
 test_glob_delete_across_refs
+test_garbage_collection
 
 echo "SUMMARY: $passed_tests image integration scenarios passed"

--- a/tests/test-image.sh
+++ b/tests/test-image.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+image="${1:?usage: tests/test-image.sh IMAGE}"
+workspace="$(mktemp -d)"
+
+cleanup() {
+  rm -rf -- "$workspace"
+}
+trap cleanup EXIT
+
+usage="$(docker run --rm "$image" 2>&1)"
+grep -F "bfg " <<<"$usage"
+grep -F -- "--delete-files" <<<"$usage"
+
+uid="$(docker run --rm --entrypoint sh "$image" -c 'id -u')"
+if ((uid == 0)); then
+  echo "expected the image to run as a non-root user" >&2
+  exit 1
+fi
+
+docker run --rm --entrypoint sh "$image" -c '
+  test "$HOME" = /home/bfg
+  test "$PWD" = /home/bfg/workspace
+  test -r /home/bfg/bfg.jar
+'
+
+git init --initial-branch=main "$workspace/source"
+git -C "$workspace/source" config user.name "CI"
+git -C "$workspace/source" config user.email "ci@example.invalid"
+git -C "$workspace/source" config commit.gpgsign false
+
+printf '%s\n' "super-secret" >"$workspace/source/credential.json"
+printf '%s\n' "keep me" >"$workspace/source/keep.txt"
+git -C "$workspace/source" add .
+git -C "$workspace/source" commit -m "Add test files"
+
+git clone --mirror "$workspace/source" "$workspace/repo.git"
+
+# GitHub-hosted runners and the image use different UIDs. Make the fixture
+# writable so the image's non-root user can rewrite the mounted repository.
+chmod -R a+rwX "$workspace"
+
+docker run --rm \
+  --volume "$workspace:/home/bfg/workspace" \
+  "$image" \
+  --no-blob-protection --delete-files credential.json repo.git
+
+git --git-dir="$workspace/repo.git" fsck --full --no-dangling
+
+deleted_file_commits="$(
+  git --git-dir="$workspace/repo.git" \
+    log --all --format=%H -- credential.json
+)"
+if [[ -n "$deleted_file_commits" ]]; then
+  echo "credential.json remains in reachable history" >&2
+  exit 1
+fi
+
+kept_content="$(
+  git --git-dir="$workspace/repo.git" \
+    show refs/heads/main:keep.txt
+)"
+if [[ "$kept_content" != "keep me" ]]; then
+  echo "unrelated file content changed during the rewrite" >&2
+  exit 1
+fi
+
+while IFS= read -r ref; do
+  if git --git-dir="$workspace/repo.git" grep -F "super-secret" "$ref"; then
+    echo "secret content remains reachable from $ref" >&2
+    exit 1
+  fi
+done < <(
+  git --git-dir="$workspace/repo.git" \
+    for-each-ref --format='%(refname)' refs/heads refs/tags
+)

--- a/tests/test-image.sh
+++ b/tests/test-image.sh
@@ -21,69 +21,205 @@ cleanup() {
 }
 trap cleanup EXIT
 
-usage="$(docker run --rm "$image" 2>&1)"
-grep -F "bfg " <<<"$usage"
-grep -F -- "--delete-files" <<<"$usage"
+fail() {
+  echo "FAIL: $*" >&2
+  return 1
+}
 
-uid="$(docker run --rm --entrypoint sh "$image" -c 'id -u')"
-if ((uid == 0)); then
-  echo "expected the image to run as a non-root user" >&2
-  exit 1
-fi
+setup_case() {
+  local name="$1"
 
-docker run --rm --entrypoint sh "$image" -c '
-  test "$HOME" = /home/bfg
-  test "$PWD" = /home/bfg/workspace
-  test -r /home/bfg/bfg.jar
-'
+  case_dir="$workspace/$name"
+  source_repo="$case_dir/source"
+  mirror_repo="$case_dir/repo.git"
 
-git init --initial-branch=main "$workspace/source"
-git -C "$workspace/source" config user.name "CI"
-git -C "$workspace/source" config user.email "ci@example.invalid"
-git -C "$workspace/source" config commit.gpgsign false
+  mkdir -p "$case_dir"
+  git init --quiet --initial-branch=main "$source_repo"
+  git -C "$source_repo" config user.name "CI"
+  git -C "$source_repo" config user.email "ci@example.invalid"
+  git -C "$source_repo" config commit.gpgsign false
+}
 
-printf '%s\n' "super-secret" >"$workspace/source/credential.json"
-printf '%s\n' "keep me" >"$workspace/source/keep.txt"
-git -C "$workspace/source" add .
-git -C "$workspace/source" commit -m "Add test files"
+commit_fixture() {
+  local message="$1"
 
-git clone --mirror "$workspace/source" "$workspace/repo.git"
+  git -C "$source_repo" add -A
+  git -C "$source_repo" commit --quiet -m "$message"
+}
 
-# GitHub-hosted runners and the image use different UIDs. Make the fixture
-# writable so the image's non-root user can rewrite the mounted repository.
-chmod -R a+rwX "$workspace"
+mirror_fixture() {
+  git clone --quiet --mirror "$source_repo" "$mirror_repo"
 
-docker run --rm \
-  --volume "$workspace:/home/bfg/workspace" \
-  "$image" \
-  --no-blob-protection --delete-files credential.json repo.git
+  # GitHub-hosted runners and the image use different UIDs. Make the fixture
+  # writable so the image's non-root user can rewrite the mounted repository.
+  chmod -R a+rwX "$case_dir"
+}
 
-git --git-dir="$workspace/repo.git" fsck --full --no-dangling
+run_bfg() {
+  docker run --rm \
+    --volume "$case_dir:/home/bfg/workspace" \
+    "$image" \
+    "$@" repo.git
+}
 
-deleted_file_commits="$(
-  git --git-dir="$workspace/repo.git" \
-    log --all --format=%H -- credential.json
-)"
-if [[ -n "$deleted_file_commits" ]]; then
-  echo "credential.json remains in reachable history" >&2
-  exit 1
-fi
+assert_repo_valid() {
+  git --git-dir="$mirror_repo" fsck --full --no-dangling
+}
 
-kept_content="$(
-  git --git-dir="$workspace/repo.git" \
-    show refs/heads/main:keep.txt
-)"
-if [[ "$kept_content" != "keep me" ]]; then
-  echo "unrelated file content changed during the rewrite" >&2
-  exit 1
-fi
+assert_ref_content() {
+  local ref="$1"
+  local path="$2"
+  local expected="$3"
+  local actual
 
-while IFS= read -r ref; do
-  if git --git-dir="$workspace/repo.git" grep -F "super-secret" "$ref"; then
-    echo "secret content remains reachable from $ref" >&2
-    exit 1
+  actual="$(git --git-dir="$mirror_repo" show "$ref:$path")"
+  [[ "$actual" == "$expected" ]] ||
+    fail "$ref:$path contained '$actual', expected '$expected'"
+}
+
+assert_ref_missing() {
+  local ref="$1"
+  local path="$2"
+
+  if git --git-dir="$mirror_repo" cat-file -e "$ref:$path" 2>/dev/null; then
+    fail "$path remains reachable from $ref"
   fi
-done < <(
-  git --git-dir="$workspace/repo.git" \
-    for-each-ref --format='%(refname)' refs/heads refs/tags
-)
+}
+
+assert_no_path_history() {
+  local path="$1"
+  local commits
+
+  commits="$(
+    git --git-dir="$mirror_repo" \
+      log --all --format=%H -- "$path"
+  )"
+  [[ -z "$commits" ]] || fail "$path remains in reachable history"
+}
+
+assert_no_reachable_text() {
+  local text="$1"
+  local ref
+
+  while IFS= read -r ref; do
+    if git --git-dir="$mirror_repo" grep -F "$text" "$ref"; then
+      fail "'$text' remains reachable from $ref"
+    fi
+  done < <(
+    git --git-dir="$mirror_repo" \
+      for-each-ref --format='%(refname)' refs/heads refs/tags
+  )
+}
+
+test_image_contract() {
+  local usage
+  local uid
+
+  echo "==> image contract"
+
+  usage="$(docker run --rm "$image" 2>&1)"
+  grep -F "bfg " <<<"$usage"
+  grep -F -- "--delete-files" <<<"$usage"
+
+  uid="$(docker run --rm --entrypoint sh "$image" -c 'id -u')"
+  ((uid != 0)) || fail "expected the image to run as a non-root user"
+
+  docker run --rm --entrypoint sh "$image" -c '
+    test "$HOME" = /home/bfg
+    test "$PWD" = /home/bfg/workspace
+    test -r /home/bfg/bfg.jar
+  '
+}
+
+test_safe_rewrite() {
+  local head_before
+  local head_after
+  local tree_before
+  local tree_after
+
+  echo "==> protected rewrite of historical content"
+  setup_case "safe-rewrite"
+
+  printf '%s\n' "super-secret" >"$source_repo/credential.json"
+  printf '%s\n' "keep me" >"$source_repo/keep.txt"
+  commit_fixture "Add historical credential"
+
+  git -C "$source_repo" rm --quiet credential.json
+  commit_fixture "Remove credential from current revision"
+  mirror_fixture
+
+  head_before="$(git --git-dir="$mirror_repo" rev-parse refs/heads/main)"
+  tree_before="$(git --git-dir="$mirror_repo" rev-parse 'refs/heads/main^{tree}')"
+
+  run_bfg --delete-files credential.json
+
+  head_after="$(git --git-dir="$mirror_repo" rev-parse refs/heads/main)"
+  tree_after="$(git --git-dir="$mirror_repo" rev-parse 'refs/heads/main^{tree}')"
+
+  [[ "$head_before" != "$head_after" ]] ||
+    fail "safe rewrite did not update history"
+  [[ "$tree_before" == "$tree_after" ]] ||
+    fail "safe rewrite changed the protected current tree"
+  assert_ref_missing refs/heads/main credential.json
+  assert_ref_content refs/heads/main keep.txt "keep me"
+  assert_no_path_history credential.json
+  assert_no_reachable_text "super-secret"
+  assert_repo_valid
+}
+
+test_protected_head() {
+  local head_before
+  local head_after
+
+  echo "==> current content remains protected by default"
+  setup_case "protected-head"
+
+  printf '%s\n' "super-secret" >"$source_repo/credential.json"
+  printf '%s\n' "keep me" >"$source_repo/keep.txt"
+  commit_fixture "Add current credential"
+  mirror_fixture
+
+  head_before="$(git --git-dir="$mirror_repo" rev-parse refs/heads/main)"
+
+  run_bfg --delete-files credential.json
+
+  head_after="$(git --git-dir="$mirror_repo" rev-parse refs/heads/main)"
+
+  [[ "$head_before" == "$head_after" ]] ||
+    fail "default protection unexpectedly changed the current commit"
+  assert_ref_content refs/heads/main credential.json "super-secret"
+  assert_ref_content refs/heads/main keep.txt "keep me"
+  assert_repo_valid
+}
+
+test_unprotected_rewrite() {
+  local head_before
+  local head_after
+
+  echo "==> unprotected rewrite of current content"
+  setup_case "unprotected-rewrite"
+
+  printf '%s\n' "super-secret" >"$source_repo/credential.json"
+  printf '%s\n' "keep me" >"$source_repo/keep.txt"
+  commit_fixture "Add current credential"
+  mirror_fixture
+
+  head_before="$(git --git-dir="$mirror_repo" rev-parse refs/heads/main)"
+
+  run_bfg --no-blob-protection --delete-files credential.json
+
+  head_after="$(git --git-dir="$mirror_repo" rev-parse refs/heads/main)"
+
+  [[ "$head_before" != "$head_after" ]] ||
+    fail "unprotected rewrite did not update the current commit"
+  assert_ref_missing refs/heads/main credential.json
+  assert_ref_content refs/heads/main keep.txt "keep me"
+  assert_no_path_history credential.json
+  assert_no_reachable_text "super-secret"
+  assert_repo_valid
+}
+
+test_image_contract
+test_safe_rewrite
+test_protected_head
+test_unprotected_rewrite

--- a/tests/test-image.sh
+++ b/tests/test-image.sh
@@ -219,7 +219,56 @@ test_unprotected_rewrite() {
   assert_repo_valid
 }
 
+test_replace_text() {
+  echo "==> replace sensitive text"
+  setup_case "replace-text"
+
+  printf '%s\n' \
+    "password=super-secret" \
+    "mode=production" \
+    >"$source_repo/application.conf"
+  printf '%s\n' "keep me" >"$source_repo/keep.txt"
+  printf '%s\n' "super-secret" >"$case_dir/replacements.txt"
+  commit_fixture "Add configuration containing a secret"
+  mirror_fixture
+
+  run_bfg \
+    --no-blob-protection \
+    --replace-text replacements.txt
+
+  assert_ref_content \
+    refs/heads/main \
+    application.conf \
+    $'password=***REMOVED***\nmode=production'
+  assert_ref_content refs/heads/main keep.txt "keep me"
+  assert_no_reachable_text "super-secret"
+  assert_repo_valid
+}
+
+test_strip_large_blobs() {
+  echo "==> strip blobs above a size threshold"
+  setup_case "strip-large-blobs"
+
+  awk 'BEGIN { for (i = 0; i < 2048; i++) printf "x" }' \
+    >"$source_repo/large.bin"
+  printf '%s\n' "small file" >"$source_repo/small.txt"
+  commit_fixture "Add large and small files"
+  mirror_fixture
+  git --git-dir="$mirror_repo" repack -ad
+
+  run_bfg \
+    --no-blob-protection \
+    --strip-blobs-bigger-than 1K
+
+  assert_ref_missing refs/heads/main large.bin
+  assert_ref_content refs/heads/main small.txt "small file"
+  assert_no_path_history large.bin
+  assert_repo_valid
+}
+
 test_image_contract
 test_safe_rewrite
 test_protected_head
 test_unprotected_rewrite
+test_replace_text
+test_strip_large_blobs

--- a/tests/test-image.sh
+++ b/tests/test-image.sh
@@ -6,7 +6,18 @@ image="${1:?usage: tests/test-image.sh IMAGE}"
 workspace="$(mktemp -d)"
 
 cleanup() {
-  rm -rf -- "$workspace"
+  exit_code=$?
+
+  docker run --rm \
+    --user root \
+    --entrypoint sh \
+    --volume "$workspace:/workspace" \
+    "$image" \
+    -c 'chmod -R a+rwX /workspace' \
+    >/dev/null 2>&1 || true
+  rm -rf -- "$workspace" || true
+
+  return "$exit_code"
 }
 trap cleanup EXIT
 

--- a/tests/test-image.sh
+++ b/tests/test-image.sh
@@ -266,9 +266,61 @@ test_strip_large_blobs() {
   assert_repo_valid
 }
 
+test_glob_delete_across_refs() {
+  local ref
+
+  echo "==> delete matching files and folders across refs"
+  setup_case "glob-delete"
+
+  mkdir -p \
+    "$source_repo/cache" \
+    "$source_repo/nested/cache"
+  printf '%s\n' "discard-root" >"$source_repo/root.log"
+  printf '%s\n' "discard-cache" >"$source_repo/cache/generated.tmp"
+  printf '%s\n' "discard-nested" >"$source_repo/nested/debug.log"
+  printf '%s\n' "discard-deep-cache" >"$source_repo/nested/cache/data.tmp"
+  printf '%s\n' "keep me" >"$source_repo/keep.txt"
+  commit_fixture "Add files on main"
+
+  git -C "$source_repo" tag before-feature
+  git -C "$source_repo" checkout --quiet -b feature
+  printf '%s\n' "discard-feature" >"$source_repo/feature.log"
+  printf '%s\n' "feature content" >"$source_repo/feature.txt"
+  commit_fixture "Add files on feature"
+  git -C "$source_repo" checkout --quiet main
+  mirror_fixture
+
+  run_bfg \
+    --no-blob-protection \
+    --delete-files '*.log' \
+    --delete-folders cache
+
+  for ref in \
+    refs/heads/main \
+    refs/heads/feature \
+    refs/tags/before-feature; do
+    assert_ref_missing "$ref" root.log
+    assert_ref_missing "$ref" cache/generated.tmp
+    assert_ref_missing "$ref" nested/debug.log
+    assert_ref_missing "$ref" nested/cache/data.tmp
+    assert_ref_content "$ref" keep.txt "keep me"
+  done
+
+  assert_ref_missing refs/heads/feature feature.log
+  assert_ref_content refs/heads/feature feature.txt "feature content"
+  assert_no_path_history root.log
+  assert_no_path_history cache/generated.tmp
+  assert_no_path_history nested/debug.log
+  assert_no_path_history nested/cache/data.tmp
+  assert_no_path_history feature.log
+  assert_no_reachable_text "discard-"
+  assert_repo_valid
+}
+
 test_image_contract
 test_safe_rewrite
 test_protected_head
 test_unprotected_rewrite
 test_replace_text
 test_strip_large_blobs
+test_glob_delete_across_refs


### PR DESCRIPTION
## Summary

This PR turns the built container into the unit under test, expands CI across both published architectures, makes security and lint findings blocking, and automates the Dockerfile dependencies that previously required manual updates.

## What changed

### Build and image testing

- build separate `linux/amd64` and `linux/arm64` test images
- pass those images between jobs as workflow artifacts instead of publishing temporary PR images to GHCR
- retain PR test-image artifacts for one day
- run the same BFG integration suite against both architectures
- reuse the platform-specific test-build caches for the final multi-platform build
- preserve the existing main, tag, scheduled, and manual image-publication behavior

The integration suite now verifies eight scenarios:

1. CLI output, bundled JAR, non-root user, home directory, and working-directory contract
2. safe removal of historical content while protecting the current tree
3. default protection of sensitive content still present at `HEAD`
4. explicitly unprotected rewriting of current content
5. sensitive-text replacement
6. size-based blob stripping
7. file and folder deletion across branches and tags
8. reflog expiration and aggressive garbage collection of unreachable data

Every rewrite also checks repository integrity, expected retained content, and removal from reachable history.

### Security, linting, and required status

- scan both amd64 and arm64 images with Trivy
- fail CI on fixable `HIGH` or `CRITICAL` vulnerabilities
- upload architecture-specific SARIF reports to the repository Security tab
- add blocking ShellCheck and Hadolint workflows
- add a stable `PR CI Gate` that verifies every required build, test, scan, and lint job succeeded

### Dependency automation

- track BFG versions from `rtyley/bfg-repo-cleaner` GitHub releases with a Renovate regex manager
- pin Alpine `shadow` exactly and keep it updated through the Alpine 3.24 Repology feed using Renovate's `apk` versioning
- verify each downloaded BFG JAR against Maven Central's version-matched checksum sidecar so Renovate version updates do not leave a stale hard-coded checksum

BFG's GitHub releases do not include JAR assets, so the image continues downloading the corresponding artifact from Maven Central.

## Artifact and publishing behavior

PR runs keep their test-image artifacts for one day and do not publish temporary images. Normal multi-platform image availability from `main`, tags, scheduled runs, and manual runs is unchanged.

## Validation

- Renovate configuration validation and dependency extraction for both custom dependencies
- `actionlint .github/workflows/*.yml`
- ShellCheck across every shell script
- Hadolint at warning threshold
- local amd64 and arm64 Buildx builds
- all eight integration scenarios against both architectures locally and in GitHub Actions
- blocking Trivy scans against both architectures with zero fixable `HIGH` or `CRITICAL` findings
- SARIF upload for both architecture scans
- aggregate `PR CI Gate`

Final CI run: https://github.com/oct8l/bfg-dockerized/actions/runs/29595615692
